### PR TITLE
fix: dateRange 미사용으로 인한 createMeeting 수정

### DIFF
--- a/packages/wow-meet-app/src/pages/create.tsx
+++ b/packages/wow-meet-app/src/pages/create.tsx
@@ -49,11 +49,10 @@ const Create = () => {
       title: body?.title || "",
       description: body?.description || "",
       schedule: {
-        type: body?.sType,
+        type: "", //고정
         TimeRanges: "", //고정
         isPriorityOption: false, //고정
         dayList: body?.dayList,
-        dateRange: body?.dateRange,
       },
       votes: [
         {


### PR DESCRIPTION
## Issue

- Resolves #25 

## Description

- 에러 해결

## Check List

- [ ]  `main` 브랜치의 최신 상태를 반영하고 있는지 확인
- [ ]  적절한 라벨 설정
- [ ]  PR에 해당되는 Issue를 연결 완료
